### PR TITLE
dashify all non-word characters in heading ids

### DIFF
--- a/lib/index.css
+++ b/lib/index.css
@@ -83,7 +83,7 @@ img, video { max-width: 100% }
   font-size: 1.2rem;
 }
 
-.docs-main h1 {
+.docs-main > h1 {
   font-weight: 300;
   font-size: 3rem;
   line-height: 1;
@@ -91,7 +91,7 @@ img, video { max-width: 100% }
 }
 
 .docs-main > blockquote,
-.docs-main h2 {
+.docs-main > h2 {
   font-weight: 300;
   font-size: 1.5em;
   line-height: 1.5;
@@ -99,7 +99,7 @@ img, video { max-width: 100% }
   max-width: 45rem;
 }
 
-.docs-main h2::before,
+.docs-main > h2::before,
 .docs-main > hr {
   content: '';
   position: relative;
@@ -115,6 +115,14 @@ img, video { max-width: 100% }
   font-size: 12px;
   margin: 2em 0 .5em;
   text-transform: uppercase;
+}
+
+.docs-main > h1 a,
+.docs-main > h2 a,
+.docs-main > h3 a,
+.docs-main > h4 a {
+  text-decoration: none;
+  color: currentColor;
 }
 
 .docs-main > ul {

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,8 +67,8 @@ function markCode (code, lang) {
 }
 
 function markHeading (text, level) {
-    const id = text.toLowerCase().replace(/[^\w]+/g, '-')
-    return `<a id="${id}" style="text-decoration: none; color: currentColor; outline: none" href="#${id}"><h${level}>${text}</h${level}></a>`
+    const id = text.toLowerCase().replace(/\W+/g, '-')
+    return `<h${level} id="${id}"><a href="#${id}">${text}</a></h${level}></a>`
 }
 
 function chooseTransform (done) {


### PR DESCRIPTION
need this for h3 so we can say https://static.nrk.no/core-components/latest/index.html?core-input/readme.md#input-select not https://static.nrk.no/core-components/latest/index.html?core-input/readme.md#inputselect

 .. + 

make headings links so you can click them and copy the changed url easily.