### PR TITLE
fix: Use custom namespace for core-tabs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,7 +139,7 @@ function generateTabs (html) {
       const a = el.querySelector('a')
       const uuid = `${group.id}-${a.id}`
 
-      if (isFirst) dom.insertBefore(tabs = document.createElement('core-tabs'), el).className = 'docs-tabs'
+      if (isFirst) dom.insertBefore(tabs = document.createElement('core-docs-tabs'), el).className = 'docs-tabs'
       tabs.insertAdjacentHTML('beforeend', `<a for="${uuid}" href="#${uuid}">${a.textContent}</a>`)
       tabs.insertAdjacentHTML('afterend', `<div id="${uuid}"${isFirst ? '' : ' hidden'}></div>`)
       dom.removeChild(el)
@@ -193,7 +193,7 @@ if (link) {
   const pageTitle = link.textContent
   const siteTitle = document.querySelector('.docs-menu a').textContent
 
-  window.customElements.define('core-tabs', CoreTabs)
+  window.customElements.define('core-docs-tabs', CoreTabs)
   document.title = pageTitle === siteTitle ? pageTitle : `${pageTitle} - ${siteTitle}`
   document.addEventListener('click', preventScrollOnTabs)
   window.addEventListener('hashchange', onHash)


### PR DESCRIPTION
Namespace for `core-tabs` changed to `core-docs-tabs`

Resolves console error present in docs for core-tabs due to duplicate namespace
https://static.nrk.no/core-components/latest/index.html?core-tabs/readme.md