### PR TITLE
feat: core-docs cascade layer

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,10 +20,4 @@
     const theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'default'; 
     mermaid.initialize({ startOnLoad: true, theme }); 
   </script> 
-  <style>
-    /* Override theme properties after core-docs script tag */
-    :root {
-      --docs-color-background--dark: #36363b;
-    }
-  </style>
 </html>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,437 +1,436 @@
 @use 'sass:meta';
 
-:root {
-  color-scheme: var(--docs-color-scheme, normal);
-  /* Values for light/default theme */
-  --docs-color-background--light: #fff;
-  --docs-color-background-code--light: #f4f4f4;
-  --docs-color-text--light: #141517;
-  --docs-color-link--light: #0059b3;
-  --docs-color-border--light: #eee;
-  --docs-color-shadow--light: #00b9f2;
+@layer core-docs {
+  :root {
+    color-scheme: var(--docs-color-scheme, normal);
+    /* Values for light/default theme */
+    --docs-color-background--light: #fff;
+    --docs-color-background-code--light: #f4f4f4;
+    --docs-color-text--light: #141517;
+    --docs-color-link--light: #0059b3;
+    --docs-color-border--light: #eee;
+    --docs-color-shadow--light: #00b9f2;
 
-  /* Values for dark theme */
-  --docs-color-background--dark: #36363b; /* NRK Gray 800 */
-  --docs-color-background-code--dark: #1d1d21; /* NRK Gray 900 */
-  --docs-color-text--dark: #f7f4f2; /* NRK Gray 50 */
-  --docs-color-link--dark: #b2cff5; /* NRK Core Blue 200 */
-  --docs-color-border--dark: #1d1d21; /* Origo shade 2 */
-  --docs-color-shadow--dark: hsla(210, 15%, 50%, 0.4); /* Origo shade 2 */
+    /* Values for dark theme */
+    --docs-color-background--dark: #36363b; /* NRK Gray 800 */
+    --docs-color-background-code--dark: #1d1d21; /* NRK Gray 900 */
+    --docs-color-text--dark: #f7f4f2; /* NRK Gray 50 */
+    --docs-color-link--dark: #b2cff5; /* NRK Core Blue 200 */
+    --docs-color-border--dark: #1d1d21; /* Origo shade 2 */
+    --docs-color-shadow--dark: hsla(210, 15%, 50%, 0.4); /* Origo shade 2 */
 
-  /* Values for toggle button */
-  --docs-toggle-shade--hsl: 210, 15%, 50%;
-}
+    /* Values for toggle button */
+    --docs-toggle-shade--hsl: 210, 15%, 50%;
+  }
 
-html {
-  font: 100%/1.6 'Open Sans', sans-serif;
-  scroll-behavior: smooth;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+  html {
+    font: 100%/1.6 'Open Sans', sans-serif;
+    scroll-behavior: smooth;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 
-body {
-  margin: 0;
-  background: var(--docs-color-background); /* Ensure Firefox darkmode does not get black background */
-  color: var(--docs-color-text);
-}
+  body {
+    margin: 0;
+    background: var(--docs-color-background); /* Ensure Firefox darkmode does not get black background */
+    color: var(--docs-color-text);
+  }
 
-a {
-  color: var(--docs-color-link);
-}
-pre,
-code {
-  overflow: auto;
-  background: var(--docs-color-background-code);
-}
-strong,
-b {
-  font-weight: 600;
-}
-img,
-video {
-  max-width: 100%;
-}
+  a {
+    color: var(--docs-color-link);
+  }
+  pre,
+  code {
+    overflow: auto;
+    background: var(--docs-color-background-code);
+  }
+  strong,
+  b {
+    font-weight: 600;
+  }
+  img,
+  video {
+    max-width: 100%;
+  }
 
-.docs-menu {
-  margin: 0;
-  padding: 30px;
-  font-size: 14px;
-  line-height: 30px;
-  background: var(--docs-color-background);
-}
+  .docs-menu {
+    margin: 0;
+    padding: 30px;
+    font-size: 14px;
+    line-height: 30px;
+    background: var(--docs-color-background);
+  }
+  .docs-menu a {
+    display: block;
+    background: 100% 50%/15px no-repeat;
+  }
+  .docs-menu a[aria-current="page"] {
+    font-weight: 600;
+  }
+  html[data-theme='light'] .docs-menu a[href*='github.com'] {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#141517' viewBox='0 0 16 16' width='20'%3E%3Cpath d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z'%2F%3E%3C%2Fsvg%3E");
+  }
+  html[data-theme='dark'] .docs-menu a[href*='github.com'] {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#f7f4f2' viewBox='0 0 16 16' width='20'%3E%3Cpath d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z'%2F%3E%3C%2Fsvg%3E");
+  }
+  html[data-theme='light'] .docs-menu a[download] {
+    background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cpath stroke='#141517' fill='none' stroke-linecap='round' d='M1.5 13.5h12M3.5 8l4 4 4-4m-4-5.5v9'/%3E%3C/svg%3E");
+  }
+  html[data-theme='dark'] .docs-menu a[download] {
+    background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cpath stroke='#f7f4f2' fill='none' stroke-linecap='round' d='M1.5 13.5h12M3.5 8l4 4 4-4m-4-5.5v9'/%3E%3C/svg%3E");
+  }
+  html[data-theme='light'] .docs-menu a[target] {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='#141517'%3E%3Cpath d='M17.4 11a.6.6 0 0 0-.601.601V15.4c0 .772-.628 1.4-1.399 1.4H4.599A1.401 1.401 0 0 1 3.2 15.4V4.601c0-.773.628-1.401 1.399-1.401H8.4a.6.6 0 1 0 0-1.2H4.599A2.603 2.603 0 0 0 2 4.601V15.4C2 16.834 3.166 18 4.599 18H15.4c1.434 0 2.6-1.166 2.6-2.6v-3.799a.6.6 0 0 0-.6-.601zm.6-9v7l-2.792-2.792-4.516 4.517-.008-.008a.99.99 0 0 1-1.138.177 1 1 0 0 1-.437-1.346c.046-.09.113-.157.18-.227l-.011-.01 4.516-4.517L11 2h7z'/%3E%3C/svg%3E");
+  }
+  html[data-theme='dark'] .docs-menu a[target] {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='#f7f4f2'%3E%3Cpath d='M17.4 11a.6.6 0 0 0-.601.601V15.4c0 .772-.628 1.4-1.399 1.4H4.599A1.401 1.401 0 0 1 3.2 15.4V4.601c0-.773.628-1.401 1.399-1.401H8.4a.6.6 0 1 0 0-1.2H4.599A2.603 2.603 0 0 0 2 4.601V15.4C2 16.834 3.166 18 4.599 18H15.4c1.434 0 2.6-1.166 2.6-2.6v-3.799a.6.6 0 0 0-.6-.601zm.6-9v7l-2.792-2.792-4.516 4.517-.008-.008a.99.99 0 0 1-1.138.177 1 1 0 0 1-.437-1.346c.046-.09.113-.157.18-.227l-.011-.01 4.516-4.517L11 2h7z'/%3E%3C/svg%3E");
+  }
 
-.docs-menu a {
-  display: block;
-  background: 100% 50%/15px no-repeat;
-}
+  .docs-menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 30px;
+  }
 
-.docs-menu a[aria-current="page"] {
-  font-weight: 600;
-}
+  .docs-menu ul ul {
+    padding: 0 30px;
+  }
+  .docs-menu a {
+    display: block;
+    color: inherit;
+    text-decoration: none;
+    line-height: 1.5;
+    padding: 0.3em 0;
+  }
 
-html[data-theme='light'] .docs-menu a[href*='github.com'] {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#141517' viewBox='0 0 16 16' width='20'%3E%3Cpath d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z'%2F%3E%3C%2Fsvg%3E");
-}
-html[data-theme='dark'] .docs-menu a[href*='github.com'] {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#f7f4f2' viewBox='0 0 16 16' width='20'%3E%3Cpath d='M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z'%2F%3E%3C%2Fsvg%3E");
-}
-html[data-theme='light'] .docs-menu a[download] {
-  background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cpath stroke='#141517' fill='none' stroke-linecap='round' d='M1.5 13.5h12M3.5 8l4 4 4-4m-4-5.5v9'/%3E%3C/svg%3E");
-}
-html[data-theme='dark'] .docs-menu a[download] {
-  background-image: url("data:image/svg+xml,%0A%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 15'%3E%3Cpath stroke='#f7f4f2' fill='none' stroke-linecap='round' d='M1.5 13.5h12M3.5 8l4 4 4-4m-4-5.5v9'/%3E%3C/svg%3E");
-}
-html[data-theme='light'] .docs-menu a[target] {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='#141517'%3E%3Cpath d='M17.4 11a.6.6 0 0 0-.601.601V15.4c0 .772-.628 1.4-1.399 1.4H4.599A1.401 1.401 0 0 1 3.2 15.4V4.601c0-.773.628-1.401 1.399-1.401H8.4a.6.6 0 1 0 0-1.2H4.599A2.603 2.603 0 0 0 2 4.601V15.4C2 16.834 3.166 18 4.599 18H15.4c1.434 0 2.6-1.166 2.6-2.6v-3.799a.6.6 0 0 0-.6-.601zm.6-9v7l-2.792-2.792-4.516 4.517-.008-.008a.99.99 0 0 1-1.138.177 1 1 0 0 1-.437-1.346c.046-.09.113-.157.18-.227l-.011-.01 4.516-4.517L11 2h7z'/%3E%3C/svg%3E");
-}
-html[data-theme='dark'] .docs-menu a[target] {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='#f7f4f2'%3E%3Cpath d='M17.4 11a.6.6 0 0 0-.601.601V15.4c0 .772-.628 1.4-1.399 1.4H4.599A1.401 1.401 0 0 1 3.2 15.4V4.601c0-.773.628-1.401 1.399-1.401H8.4a.6.6 0 1 0 0-1.2H4.599A2.603 2.603 0 0 0 2 4.601V15.4C2 16.834 3.166 18 4.599 18H15.4c1.434 0 2.6-1.166 2.6-2.6v-3.799a.6.6 0 0 0-.6-.601zm.6-9v7l-2.792-2.792-4.516 4.517-.008-.008a.99.99 0 0 1-1.138.177 1 1 0 0 1-.437-1.346c.046-.09.113-.157.18-.227l-.011-.01 4.516-4.517L11 2h7z'/%3E%3C/svg%3E");
-}
+  .docs-menu .docs-menu-break {
+    padding-top: 2rem;
+  }
 
-.docs-menu ul {
-  list-style: none;
-  margin: 0;
-  padding: 0 0 30px;
-}
+  /* Allow remember scroll position */
+  .docs-main:empty {
+    min-height: 9000px;
+    opacity: 0;
+  }
 
-.docs-menu ul ul {
-  padding: 0 30px;
-}
-.docs-menu a {
-  display: block;
-  color: inherit;
-  text-decoration: none;
-  line-height: 1.5;
-  padding: 0.3em 0;
-}
+  .docs-main {
+    display: block;
+    overflow: hidden;
+    padding: 4rem 7vw 8rem;
+    transition: 1s;
+  }
 
-.docs-menu .docs-menu-break {
-  padding-top: 2rem;
-}
+  .docs-p {
+    font-size: 1rem;
+  }
 
-/* Allow remember scroll position */
-.docs-main:empty {
-  min-height: 9000px;
-  opacity: 0;
-}
+  .docs-quote,
+  .docs-p {
+    max-width: 45rem;
+    margin: 0 0 1rem;
+  }
 
-.docs-main {
-  display: block;
-  overflow: hidden;
-  padding: 4rem 7vw 8rem;
-  transition: 1s;
-}
+  .docs-quote .docs-p {
+    font-size: 1.3rem;
+  }
 
-.docs-p {
-  font-size: 1rem;
-}
+  .docs-heading--1 {
+    font-weight: 300;
+    font-size: 3rem;
+    line-height: 1;
+    margin-top: 0;
+  }
 
-.docs-quote,
-.docs-p {
-  max-width: 45rem;
-  margin: 0 0 1rem;
-}
+  .docs-quote p,
+  .docs-heading--2 {
+    font-weight: 300;
+    font-size: 2rem;
+    line-height: 1.3;
+    margin: 0.5em 0;
+    max-width: 45rem;
+  }
 
-.docs-quote .docs-p {
-  font-size: 1.3rem;
-}
+  .docs-heading--2::before,
+  .docs-ruler {
+    content: '';
+    position: relative;
+    display: block;
+    width: 100vw;
+    margin: 4rem -7vw;
+    border: 0;
+    border-top: 1px solid var(--docs-color-border);
+  }
 
-.docs-heading--1 {
-  font-weight: 300;
-  font-size: 3rem;
-  line-height: 1;
-  margin-top: 0;
-}
+  .docs-heading--3 {
+    font-weight: 600;
+    font-size: 1rem;
+    margin: 2em 0 0.5em;
+  }
 
-.docs-quote p,
-.docs-heading--2 {
-  font-weight: 300;
-  font-size: 2rem;
-  line-height: 1.3;
-  margin: 0.5em 0;
-  max-width: 45rem;
-}
+  .docs-heading--4 {
+    font-weight: 600;
+    font-size: 0.8rem;
+    margin: 2em 0 0.5em;
+  }
 
-.docs-heading--2::before,
-.docs-ruler {
-  content: '';
-  position: relative;
-  display: block;
-  width: 100vw;
-  margin: 4rem -7vw;
-  border: 0;
-  border-top: 1px solid var(--docs-color-border);
-}
+  .docs-heading a {
+    text-decoration: none;
+    color: inherit;
+  }
 
-.docs-heading--3 {
-  font-weight: 600;
-  font-size: 1rem;
-  margin: 2em 0 0.5em;
-}
+  .docs-list {
+    padding-left: 25px;
+    list-style: url("data:image/svg+xml,%3Csvg width='25' height='10' viewBox='0 0 7 10' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4-4 4' stroke='%23ccc' stroke-width='2' fill='none'/%3E%3C/svg%3E");
+  }
 
-.docs-heading--4 {
-  font-weight: 600;
-  font-size: 0.8rem;
-  margin: 2em 0 0.5em;
-}
+  .docs-code {
+    padding: 1em;
+  }
 
-.docs-heading a {
-  text-decoration: none;
-  color: inherit;
-}
+  .docs-table th {
+    font-weight: 600;
+    font-size: 12px;
+  }
 
-.docs-list {
-  padding-left: 25px;
-  list-style: url("data:image/svg+xml,%3Csvg width='25' height='10' viewBox='0 0 7 10' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4-4 4' stroke='%23ccc' stroke-width='2' fill='none'/%3E%3C/svg%3E");
-}
+  .docs-table td {
+    min-width: 140px;
+    font-size: 14px;
+    line-height: 1.5;
+    padding: 9px 2em 9px 0;
+    border-top: 1px solid var(--docs-color-border);
+    vertical-align: top;
+  }
 
-.docs-code {
-  padding: 1em;
-}
+  .docs-table {
+    table-layout: fixed;
+    width: 100%;
+    margin: 2rem 0;
+  }
 
-.docs-table th {
-  font-weight: 600;
-  font-size: 12px;
-}
+  .docs-main code {
+    width: auto;
+    word-break: break-word;
+  }
 
-.docs-table td {
-  min-width: 140px;
-  font-size: 14px;
-  line-height: 1.5;
-  padding: 9px 2em 9px 0;
-  border-top: 1px solid var(--docs-color-border);
-  vertical-align: top;
-}
+  .docs-demo {
+    border: 3px solid var(--docs-color-background-code);
+    padding: 1rem;
+    margin: 1rem 0;
+  }
 
-.docs-table {
-  table-layout: fixed;
-  width: 100%;
-  margin: 2rem 0;
-}
+  .docs-demo > details summary {
+    cursor: pointer;
+    padding: 5px 1rem;
+    font-weight: 600;
+    font-size: 13px;
+    text-transform: capitalize;
+  }
+  .docs-demo > details {
+    background: var(--docs-color-background-code);
+    margin: 1rem calc(-1rem - 3px) calc(-1rem - 3px);
+  }
+  .docs-demo > details::after {
+    content: '';
+    display: table; /* Fix margin collapse */
+  }
+  .docs-demo pre {
+    margin: 0;
+  }
 
-.docs-main code {
-  width: auto;
-  word-break: break-word;
-}
+  .docs-tabs {
+    overflow: hidden;
+    margin: 1em 0;
+  }
+  .docs-tabs::after {
+    content: '';
+    box-sizing: border-box;
+    overflow: hidden; /* Triggers hasLayout */
+    display: block;
+    height: 40px;
+    border-bottom: 1px solid var(--docs-color-border);
+  }
+  .docs-tabs > a {
+    float: left;
+    box-sizing: border-box;
+    text-decoration: none;
+    padding: 0 1em;
+    border: 1px solid transparent;
+    border-bottom-color: var(--docs-color-border);
+    outline-offset: -7px;
+    color: inherit;
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 40px;
+    height: 40px;
+  }
+  .docs-tabs > a[aria-selected='true'] {
+    border-color: var(--docs-color-border) var(--docs-color-border) transparent;
+  }
+  .docs-tabs ~ div {
+    outline: 0;
+  } /* Hide outline from panels */
+  [role='tabpanel'] {
+    margin-top: 1em;
+  }
 
-.docs-demo {
-  border: 3px solid var(--docs-color-background-code);
-  padding: 1rem;
-  margin: 1rem 0;
-}
+  .docs-toggle-label {
+    align-items: center;
+    cursor: pointer;
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+  }
 
-.docs-demo > details summary {
-  cursor: pointer;
-  padding: 5px 1rem;
-  font-weight: 600;
-  font-size: 13px;
-  text-transform: capitalize;
-}
-.docs-demo > details {
-  background: var(--docs-color-background-code);
-  margin: 1rem calc(-1rem - 3px) calc(-1rem - 3px);
-}
-.docs-demo > details::after {
-  content: '';
-  display: table; /* Fix margin collapse */
-}
-.docs-demo pre {
-  margin: 0;
-}
-
-.docs-tabs {
-  overflow: hidden;
-  margin: 1em 0;
-}
-.docs-tabs::after {
-  content: '';
-  box-sizing: border-box;
-  overflow: hidden; /* Triggers hasLayout */
-  display: block;
-  height: 40px;
-  border-bottom: 1px solid var(--docs-color-border);
-}
-.docs-tabs > a {
-  float: left;
-  box-sizing: border-box;
-  text-decoration: none;
-  padding: 0 1em;
-  border: 1px solid transparent;
-  border-bottom-color: var(--docs-color-border);
-  outline-offset: -7px;
-  color: inherit;
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 40px;
-  height: 40px;
-}
-.docs-tabs > a[aria-selected='true'] {
-  border-color: var(--docs-color-border) var(--docs-color-border) transparent;
-}
-.docs-tabs ~ div {
-  outline: 0;
-} /* Hide outline from panels */
-[role='tabpanel'] {
-  margin-top: 1em;
-}
-
-.docs-toggle-label {
-  align-items: center;
-  cursor: pointer;
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-}
-
-.docs-toggle {
-  height: 100%;
-  width: 100%;
-  appearance: none;
-  background: transparent;
-  border-radius: 3em;
-  background-color: var(--docs-color-text);
-  cursor: pointer;
-  margin: 0;
-
-  &-wrapper {
-    $size: 1.8em;
-    font-size: 18px;
-    height: $size;
-    width: $size;
+  .docs-toggle {
+    height: 100%;
+    width: 100%;
+    appearance: none;
+    background: transparent;
     border-radius: 3em;
+    background-color: var(--docs-color-text);
+    cursor: pointer;
+    margin: 0;
 
-    html[data-theme='light'] &,
-    html & {
-      border: 1px solid hsla(var(--docs-toggle-shade--hsl), 0.4);
-      box-shadow: 0 0 0 3px hsla(var(--docs-toggle-shade--hsl), 0.2);
+    &-wrapper {
+      $size: 1.8em;
+      font-size: 18px;
+      height: $size;
+      width: $size;
+      border-radius: 3em;
+
+      html[data-theme='light'] &,
+      html & {
+        border: 1px solid hsla(var(--docs-toggle-shade--hsl), 0.4);
+        box-shadow: 0 0 0 3px hsla(var(--docs-toggle-shade--hsl), 0.2);
+
+        &:hover {
+          box-shadow: 0 0 0 3px hsla(var(--docs-toggle-shade--hsl), 0.2),
+            inset 0 0 0 6px hsla(var(--docs-toggle-shade--hsl), 0.1),
+            inset 0 0 0 2px hsla(var(--docs-toggle-shade--hsl), 0.2);
+        }
+      }
+
+      html[data-theme='dark'] & {
+        box-shadow: 0 0 0 1px hsla(var(--docs-toggle-shade--hsl), 0.4),
+          0 0 0 10px hsla(var(--docs-toggle-shade--hsl), 0.1);
+
+        &:hover {
+          box-shadow: 0 0 0 1px hsla(var(--docs-toggle-shade--hsl), 0.4),
+            0 0 0 10px hsla(var(--docs-toggle-shade--hsl), 0.1), inset 0 0 0 2px hsla(208, 76%, 97%, 0.1);
+        }
+      }
+
+      &:focus-within,
+      &:focus-visible {
+        outline: 5px auto Highlight;
+        outline: 5px auto -webkit-focus-ring-color;
+      }
 
       &:hover {
-        box-shadow: 0 0 0 3px hsla(var(--docs-toggle-shade--hsl), 0.2),
-          inset 0 0 0 6px hsla(var(--docs-toggle-shade--hsl), 0.1),
-          inset 0 0 0 2px hsla(var(--docs-toggle-shade--hsl), 0.2);
+        box-shadow: inset 0 0 0 6px hsla(var(--docs-toggle-shade--hsl), 0.1),
+          inset 0 0 0 2px hsla(var(--docs-toggle-shade--hsl), 0.3);
       }
     }
 
     html[data-theme='dark'] & {
-      box-shadow: 0 0 0 1px hsla(var(--docs-toggle-shade--hsl), 0.4),
-        0 0 0 10px hsla(var(--docs-toggle-shade--hsl), 0.1);
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='black' d='M 15 3 L 15 8 L 17 8 L 17 3 Z M 7.5 6.09375 L 6.09375 7.5 L 9.625 11.0625 L 11.0625 9.625 Z M 24.5 6.09375 L 20.9375 9.625 L 22.375 11.0625 L 25.90625 7.5 Z M 16 9 C 12.144531 9 9 12.144531 9 16 C 9 19.855469 12.144531 23 16 23 C 19.855469 23 23 19.855469 23 16 C 23 12.144531 19.855469 9 16 9 Z M 16 11 C 18.773438 11 21 13.226563 21 16 C 21 18.773438 18.773438 21 16 21 C 13.226563 21 11 18.773438 11 16 C 11 13.226563 13.226563 11 16 11 Z M 3 15 L 3 17 L 8 17 L 8 15 Z M 24 15 L 24 17 L 29 17 L 29 15 Z M 9.625 20.9375 L 6.09375 24.5 L 7.5 25.90625 L 11.0625 22.375 Z M 22.375 20.9375 L 20.9375 22.375 L 24.5 25.90625 L 25.90625 24.5 Z M 15 24 L 15 29 L 17 29 L 17 24 Z'/%3E%3C/svg%3E");
+      mask-repeat: no-repeat;
+      mask-position: center;
+      mask-size: 1rem;
+    }
 
-      &:hover {
-        box-shadow: 0 0 0 1px hsla(var(--docs-toggle-shade--hsl), 0.4),
-          0 0 0 10px hsla(var(--docs-toggle-shade--hsl), 0.1), inset 0 0 0 2px hsla(208, 76%, 97%, 0.1);
+    html[data-theme='light'] &,
+    html & {
+      mask-image: url("data:image/svg+xml,%3Csvg width='21' height='21' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Edark mode%3C/title%3E%3Cpath d='m-5.59175,-0.45294zm17.28125,0.9375l-1.65625,0.0625c-5.34375,0.19141 -9.625,4.57813 -9.625,9.96875c0,5.51172 4.48828,10 10,10c5.39063,0 9.77734,-4.28125 9.96875,-9.625l0.0625,-1.625l-1.46875,0.6875c-0.78125,0.37109 -1.64844,0.5625 -2.5625,0.5625c-3.32422,0 -6,-2.67578 -6,-6c0,-0.91406 0.22266,-1.75 0.59375,-2.53125l0.6875,-1.5zm-2.90625,2.375c-0.125,0.55469 -0.375,1.0625 -0.375,1.65625c0,4.40625 3.59375,8 8,8c0.60547,0 1.12109,-0.24609 1.6875,-0.375c-0.76172,3.625 -3.82812,6.375 -7.6875,6.375c-4.42969,0 -8,-3.57031 -8,-8c0,-3.85156 2.75781,-6.88672 6.375,-7.65625z' id='svg_1'/%3E%3C/svg%3E");
+      mask-repeat: no-repeat;
+      mask-position: 50% 50%;
+      mask-size: 1rem;
+    }
+  }
+
+  @media (min-width: 700px) {
+    .docs-main {
+      margin-left: 270px;
+    }
+    .docs-menu {
+      overflow: auto;
+      box-sizing: border-box;
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      padding: 4rem 2em;
+      width: 270px;
+      min-height: 100vh;
+      border-right: 1px solid var(--docs-color-border);
+      z-index: 1;
+    }
+  }
+
+  html,
+  html[data-theme='light'] {
+    code {
+      @include meta.load-css('~highlight.js/styles/a11y-light');
+      .hljs {
+        background-color: unset;
+
+        /* 
+          color constrast adjustment for:
+            --docs-color-background-code--light: #f4f4f4;
+        */
+        &-section,
+        &-title {
+          color: #00779e;
+        }
+
+        /* 
+          color constrast adjustment for:
+            --docs-color-background-code--light: #f4f4f4;
+        */
+        &-attribute,
+        &-built_in,
+        &-link,
+        &-literal,
+        &-meta,
+        &-number,
+        &-params,
+        &-type {
+          color: #a85d00;
+        }
       }
     }
 
-    &:focus-within,
-    &:focus-visible {
-      outline: 5px auto Highlight;
-      outline: 5px auto -webkit-focus-ring-color;
-    }
-
-    &:hover {
-      box-shadow: inset 0 0 0 6px hsla(var(--docs-toggle-shade--hsl), 0.1),
-        inset 0 0 0 2px hsla(var(--docs-toggle-shade--hsl), 0.3);
+    body {
+      --docs-color-background: var(--docs-color-background--light);
+      --docs-color-background-code: var(--docs-color-background-code--light);
+      --docs-color-text: var(--docs-color-text--light);
+      --docs-color-link: var(--docs-color-link--light);
+      --docs-color-border: var(--docs-color-border--light);
+      --docs-color-shadow: var(--docs-color-shadow--light);
     }
   }
 
-  html[data-theme='dark'] & {
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='black' d='M 15 3 L 15 8 L 17 8 L 17 3 Z M 7.5 6.09375 L 6.09375 7.5 L 9.625 11.0625 L 11.0625 9.625 Z M 24.5 6.09375 L 20.9375 9.625 L 22.375 11.0625 L 25.90625 7.5 Z M 16 9 C 12.144531 9 9 12.144531 9 16 C 9 19.855469 12.144531 23 16 23 C 19.855469 23 23 19.855469 23 16 C 23 12.144531 19.855469 9 16 9 Z M 16 11 C 18.773438 11 21 13.226563 21 16 C 21 18.773438 18.773438 21 16 21 C 13.226563 21 11 18.773438 11 16 C 11 13.226563 13.226563 11 16 11 Z M 3 15 L 3 17 L 8 17 L 8 15 Z M 24 15 L 24 17 L 29 17 L 29 15 Z M 9.625 20.9375 L 6.09375 24.5 L 7.5 25.90625 L 11.0625 22.375 Z M 22.375 20.9375 L 20.9375 22.375 L 24.5 25.90625 L 25.90625 24.5 Z M 15 24 L 15 29 L 17 29 L 17 24 Z'/%3E%3C/svg%3E");
-    mask-repeat: no-repeat;
-    mask-position: center;
-    mask-size: 1rem;
-  }
+  html[data-theme='dark'] {
+    --docs-color-scheme: dark;
 
-  html[data-theme='light'] &,
-  html & {
-    mask-image: url("data:image/svg+xml,%3Csvg width='21' height='21' xmlns='http://www.w3.org/2000/svg'%3E%3Ctitle%3Edark mode%3C/title%3E%3Cpath d='m-5.59175,-0.45294zm17.28125,0.9375l-1.65625,0.0625c-5.34375,0.19141 -9.625,4.57813 -9.625,9.96875c0,5.51172 4.48828,10 10,10c5.39063,0 9.77734,-4.28125 9.96875,-9.625l0.0625,-1.625l-1.46875,0.6875c-0.78125,0.37109 -1.64844,0.5625 -2.5625,0.5625c-3.32422,0 -6,-2.67578 -6,-6c0,-0.91406 0.22266,-1.75 0.59375,-2.53125l0.6875,-1.5zm-2.90625,2.375c-0.125,0.55469 -0.375,1.0625 -0.375,1.65625c0,4.40625 3.59375,8 8,8c0.60547,0 1.12109,-0.24609 1.6875,-0.375c-0.76172,3.625 -3.82812,6.375 -7.6875,6.375c-4.42969,0 -8,-3.57031 -8,-8c0,-3.85156 2.75781,-6.88672 6.375,-7.65625z' id='svg_1'/%3E%3C/svg%3E");
-    mask-repeat: no-repeat;
-    mask-position: 50% 50%;
-    mask-size: 1rem;
-  }
-}
+    code {
+      @include meta.load-css('~highlight.js/styles/a11y-dark');
+    }
 
-@media (min-width: 700px) {
-  .docs-main {
-    margin-left: 270px;
-  }
-  .docs-menu {
-    overflow: auto;
-    box-sizing: border-box;
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    padding: 4rem 2em;
-    width: 270px;
-    min-height: 100vh;
-    border-right: 1px solid var(--docs-color-border);
-    z-index: 1;
-  }
-}
-
-html,
-html[data-theme='light'] {
-  code {
-    @include meta.load-css('~highlight.js/styles/a11y-light');
-    .hljs {
-      background-color: unset;
-
-      /* 
-        color constrast adjustment for:
-          --docs-color-background-code--light: #f4f4f4;
-      */
-      &-section,
-      &-title {
-        color: #00779e;
-      }
-
-      /* 
-        color constrast adjustment for:
-          --docs-color-background-code--light: #f4f4f4;
-      */
-      &-attribute,
-      &-built_in,
-      &-link,
-      &-literal,
-      &-meta,
-      &-number,
-      &-params,
-      &-type {
-        color: #a85d00;
-      }
+    body {
+      --docs-color-background: var(--docs-color-background--dark);
+      --docs-color-background-code: var(--docs-color-background-code--dark);
+      --docs-color-text: var(--docs-color-text--dark);
+      --docs-color-link: var(--docs-color-link--dark);
+      --docs-color-border: var(--docs-color-border--dark);
+      --docs-color-shadow: var(--docs-color-shadow--dark);
     }
   }
 
-  body {
-    --docs-color-background: var(--docs-color-background--light);
-    --docs-color-background-code: var(--docs-color-background-code--light);
-    --docs-color-text: var(--docs-color-text--light);
-    --docs-color-link: var(--docs-color-link--light);
-    --docs-color-border: var(--docs-color-border--light);
-    --docs-color-shadow: var(--docs-color-shadow--light);
+  .docs-codespan {
+    padding: 0.2em 0.4em;
+    margin: 0;
+    font-size: 85%;
+    background-color: var(--docs-color-background-code);
+    border-radius: 6px;
   }
-}
-
-html[data-theme='dark'] {
-  --docs-color-scheme: dark;
-
-  code {
-    @include meta.load-css('~highlight.js/styles/a11y-dark');
-  }
-
-  body {
-    --docs-color-background: var(--docs-color-background--dark);
-    --docs-color-background-code: var(--docs-color-background-code--dark);
-    --docs-color-text: var(--docs-color-text--dark);
-    --docs-color-link: var(--docs-color-link--dark);
-    --docs-color-border: var(--docs-color-border--dark);
-    --docs-color-shadow: var(--docs-color-shadow--dark);
-  }
-}
-
-.docs-codespan {
-  padding: 0.2em 0.4em;
-  margin: 0;
-  font-size: 85%;
-  background-color: var(--docs-color-background-code);
-  border-radius: 6px;
 }

--- a/src/readme.md
+++ b/src/readme.md
@@ -235,19 +235,7 @@ Use theme conditioned classes `{{ 'button-light' : 'button-dark' }}` to apply cu
 
 ### Specify your own theme
 
-If you want to give your core-docs implementation a specific look and feel, you can override the CSS custom properties after the core-docs script-tag in your `index.html`-file similar to the example below:
-
-```html
-<script src="https://static.nrk.no/core-docs/latest/core-docs.min.js" charset="utf-8"></script>
-<style>
-  /* Override theme properties after core-docs script tag */
-  :root {
-    --docs-color-background--dark: #36363b;
-  }
-</style>
-```
-
-The following CSS Custom properties are used for core-docs look and feel:
+If you want to override core-docs default themes, you can override the default CSS color profile. The following CSS Custom properties controls core-docs `light` and ` dark` theme:
 
 ```CSS
 :root {
@@ -268,6 +256,8 @@ The following CSS Custom properties are used for core-docs look and feel:
   --docs-color-shadow--dark: hsla(210, 15%, 50%, 0.4);
 }
 ```
+
+Default styles for core docs are defined as `@layer core-docs` ([cascade layer](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Cascade_layers)). Any overriding un-layered styles have higher presidence independent of stylesheet order in the document.
 
 _Please note that overriding the `docs-code-background--light` or `docs-code-background--dark` colors will likely lead to contrast issues, and we do not recommend adjusting these. Minor adjustments to hljs theme [A 11 Y Light](https://highlightjs.org/static/demo/) was necessary to be WCAG compliant with `docs-code-background--light`. Thus hljs colors deviate from what is presented in native docs._
 


### PR DESCRIPTION
[ISSUE] Overriding CSS in a `style` tag after core-docs `script` declaration has it's limitations:
1. To override any selector rule with a css file appended to head properties has to be `!important`
2. Writing CSS in a HTML document is a lesser then great developer experience IMO

[SOLUTION] CSS cascade layers provide better stylesheet specificity control:
1. Any non-layered styles have higher specificity, thus overriding style does not require `!important`
2. Styles can be appended anywhere in the document and have higher specificity