### PR TITLE
fix: update label for theme checkbox to 'Dark theme'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types'
 import styles from './index.scss'
 
 const SESSION_STORAGE_SELECTED_THEME_KEY = 'docs-theme-user-state'
-const DEFAULT_THEME_TOGGLE_LABEL = 'Toggle color theme'
+const DEFAULT_THEME_TOGGLE_LABEL = 'Dark theme'
 
 /**
  * @typedef {object} themeOptions

--- a/src/readme.md
+++ b/src/readme.md
@@ -197,7 +197,7 @@ To turn on theme switching, set the `theme` option to `true` or assign an object
 <script>
   window.coreDocs = {
     theme: {
-      label: 'Dark theme', // theme toggle label (default: 'Dark theme')
+      label: 'Dark theme', // theme input[type="checkbox"] label (default: 'Dark theme')
       prefers: true, // use system settings for light or dark mode (default: true)
     },
   }

--- a/src/readme.md
+++ b/src/readme.md
@@ -197,7 +197,7 @@ To turn on theme switching, set the `theme` option to `true` or assign an object
 <script>
   window.coreDocs = {
     theme: {
-      label: 'Toggle color theme', // theme toggle label (default: 'Toggle color theme')
+      label: 'Dark theme', // theme toggle label (default: 'Dark theme')
       prefers: true, // use system settings for light or dark mode (default: true)
     },
   }


### PR DESCRIPTION
Currently there is no context to discern which theme is active for screen-reader users.

Leveraging the input element checked-state, being bound to the dark theme, and changing the default label to "Dark theme"  it becomes more evident what theme is presently active.

This change ought to qualify as a patch and will thus update for all consumers of static `major/4` (most `core/`) artefacts.