### PR TITLE
Revert "chore(deps): Bump marked from 11.0.1 to 15.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@webcomponents/custom-elements": "1.6.0",
         "core-js": "3.38.1",
         "highlight.js": "11.9.0",
-        "marked": "15.0.0",
+        "marked": "11.0.1",
         "prop-types": "15.8.1",
         "raf": "3.4.1",
         "react": "18.2.0",
@@ -5109,9 +5109,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.0.tgz",
-      "integrity": "sha512-0mouKmBROJv/WSHJBPZZyYofUgawMChnD5je/g+aOBXsHDjb/IsnTQj7mnhQZu+qPJmRQ0ecX3mLGEUm3BgwYA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.0.1.tgz",
+      "integrity": "sha512-P4kDhFEMlvLePBPRwOcMOv6+lYUbhfbSxJFs3Jb4Qx7v6K7l+k8Dxh9CEGfRvK71tL+qIFz5y7Pe4uzt4+/A3A==",
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@webcomponents/custom-elements": "1.6.0",
     "core-js": "3.38.1",
     "highlight.js": "11.9.0",
-    "marked": "15.0.0",
+    "marked": "11.0.1",
     "prop-types": "15.8.1",
     "raf": "3.4.1",
     "react": "18.2.0",


### PR DESCRIPTION
Reverts nrkno/core-docs#451

breaking changes i release https://github.com/markedjs/marked/releases/tag/v13.0.0 

text.toLowerCase() finnes ikke